### PR TITLE
Draft of hal_nordic layer

### DIFF
--- a/nrfe/nrfe_gpio.h
+++ b/nrfe/nrfe_gpio.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024, Nordic Semiconductor ASA
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef NRFE_GPIO_H
+#define NRFE_GPIO_H
+
+#include <drivers/nrfx_common.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @brief eGPIO opcodes. */
+typedef enum
+{
+    NRFE_GPIO_PIN_CONFIGURE	= 0, ///< Configure eGPIO pin.
+    NRFE_GPIO_PIN_CLEAR    	= 1, ///< Clear eGPIO pin.
+    NRFE_GPIO_PIN_SET      	= 2, ///< Set eGPIO pin.
+    NRFE_GPIO_PIN_TOGGLE   	= 3, ///< Toggle eGPIO pin.
+} nrfe_gpio_opcode_t;
+
+/** @brief eGPIO data packet. */
+typedef struct __attribute__((packed)) {
+	nrfe_gpio_opcode_t opcode:8; /* eGPIO opcode. */
+	uint32_t           pin;	     /* Pin number when opcode is NRFE_GPIO_PIN_CONFIGURE, pin mask for others. */
+	uint8_t		       port;     /* Port number. */
+	uint32_t           flags;    /* Configuration flags when opcode is NRFE_GPIO_PIN_CONFIGURE (gpio_flags_t), not used in other cases. */
+} nrfe_gpio_data_packet_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NRFE_GPIO_H */


### PR DESCRIPTION
Draft of hal_nordic layer for emulated GPIO.

~~This layer is a backend layer for emulated GPIO. It contains a function for establishing communication with FLPR (eperiphs_init) and a function for sending data to FLPR (eperiphs_send). eperiphs_send can be used to send GPIO configuration data to FLPR (initial pin state, open drain/open source, etc.) or to change state of a given GPIO (set, clear or toggle).
Function for receiving data is not needed for emulated GPIO, so I left it empty for now.~~

~~I assumed that FLPR could be in two states: firstly, FLPR would be in configuration/initialization step where it would wait for configuration data and eperipheral selection (which eperipheral should be used, for example: GPIO, QSPI, etc.). Sending eperipheral selection and configuration is not needed for now (it could be done by default by FLPR), since we only have GPIO, but it's not much more work I thought it would be nice to have it already.~~

~~The second state of FLPR would be to wait for any messages with new GPIO state (or data to send in other eperipherals).~~

~~The intention was that GPIO SHIM on APP would call eperiphs_init and eperiphs_send with configuration in its init function and other SHIM functions would call eperiphs_send with new GPIO pin state.~~

~~GPIO SHIM part is still in progress, but I thought I would share it with you already in case it needed some changing or this whole concept was wrong and ended up in trash 😒~~

~~I assumed that reconfiguring eperipheral and changing eperipheral selection is not possible. This means, that only one pin can be used with eGPIO (Zephyr configures only one pin at a time). However, reconfiguration of eperipheral can be added by modifying configuration "frame".~~

~~Please, review only the general concept. Names of functions and structs can be changed, I just used the first ones that came to my mind.~~

~~@masz-nordic, please, check, if this is what you had in mind.~~

Changed to one header with definition of enums and data struct only.

SHIM: https://github.com/magp-nordic/zephyr/pull/2